### PR TITLE
write custom.css in /tmp so the extension can work in readonly fs

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -649,7 +649,7 @@ class Extension {
     }
 
     // log(styles);
-    this._style.build('custom', styles);
+    this._style.build('custom-search-light', styles);
   }
 
   _toggle_search_light() {

--- a/style.js
+++ b/style.js
@@ -4,7 +4,7 @@ const { St, Shell, GObject, Gio, GLib, Gtk, Meta, Clutter } = imports.gi;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
-const CustomStylesPath = Me.dir.get_child('./').get_path();
+const CustomStylesPath = "/tmp";
 
 var Style = class {
   constructor() {


### PR DESCRIPTION
Write custom.css in /tmp so the extension can work in readonly fs. This is needed to make search-light work when installed by Nix/NixOS.