### PR TITLE
Fix invalid link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $ make
 
 From Gnome Extensions Repository
 
-Visit [[repository](http://https://extensions.gnome.org/extension/5489/search-light/)](http://https://extensions.gnome.org/extension/5489/search-light/)
+Visit [[repository](https://extensions.gnome.org/extension/5489/search-light/)](https://extensions.gnome.org/extension/5489/search-light/)
 
 ### Keybinding
 


### PR DESCRIPTION
Repository link in Readme had http:// and https:// both