### PR TITLE
Fixed `repository` link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ make
 
 From Gnome Extensions Repository
 
-Visit [[repository](https://extensions.gnome.org/extension/5489/search-light/)](https://extensions.gnome.org/extension/5489/search-light/)
+Visit [repository](https://extensions.gnome.org/extension/5489/search-light/)
 
 ### Keybinding
 


### PR DESCRIPTION
The link to the Gnome extensions repository was incorrectly formatted.