### PR TITLE
fix(metadata): remove duplicated uuid in metatada.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,6 @@
     "45", "46", "47", "48"
   ],
   "url": "https://github.com/icedman/search-light",
-  "uuid": "search-light@icedman.github.com",
   "schema-id": "org.gnome.shell.extensions.search-light",
   "gettext-domain": "search-light",
   "version": 100


### PR DESCRIPTION
Hi 👋🏼 

Just a basic fix removing the duplicated `uuid` in `metadata.json`