### PR TITLE
Add GNOME 50 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ test-shell-g44: g44
 	env GNOME_SHELL_SLOWDOWN_FACTOR=2 \
 		MUTTER_DEBUG_DUMMY_MODE_SPECS=1200x800 \
 	 	MUTTER_DEBUG_DUMMY_MONITOR_SCALES=1 \
-		dbus-run-session -- gnome-shell --nested --wayland
+		dbus-run-session -- gnome-shell --devkit --wayland
 	rm /run/user/1000/gnome-shell-disable-extensions
 
 test-prefs:
@@ -78,7 +78,7 @@ test-shell: install
 	env GNOME_SHELL_SLOWDOWN_FACTOR=1 \
 		MUTTER_DEBUG_DUMMY_MODE_SPECS=1280x800 \
 	 	MUTTER_DEBUG_DUMMY_MONITOR_SCALES=1.5 \
-		dbus-run-session -- gnome-shell --nested --wayland
+		dbus-run-session -- gnome-shell --devkit --wayland
 	rm /run/user/1000/gnome-shell-disable-extensions
 
 lint:

--- a/extension.js
+++ b/extension.js
@@ -149,7 +149,6 @@ export default class SearchLightExt extends Extension {
 
     Main.layoutManager.addChrome(this.mainContainer, {
       affectsStruts: false,
-      affectsInputRegion: true,
       trackFullscreen: false,
     });
 

--- a/metadata.json
+++ b/metadata.json
@@ -3,10 +3,10 @@
   "description": "Take the apps search out of overview.",
   "uuid": "search-light@icedman.github.com",
   "shell-version": [
-    "48", "49"
+    "48", "49", "50"
   ],
   "url": "https://github.com/icedman/search-light",
   "schema-id": "org.gnome.shell.extensions.search-light",
   "gettext-domain": "search-light",
-  "version": 100
+  "version": 101
 }


### PR DESCRIPTION
This PR adds GNOME 50 support.

- Add `50` into shell-version in metadata.json
- Remove unsupported param `affectsInputRegion` for Main.layoutManager.addChrome in extension.js. See the [upstream changes](https://gitlab.gnome.org/GNOME/gnome-shell/-/commit/71b19fa4222463c9a28fcb6659570a8d0f6e040c#837b4e5d58c4558697373946f9cbfdd1f5b39495) for more.

