### PR TITLE
Hide the entry before detaching it in _release_ui (shell crash on GNOME 50)

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -752,6 +752,7 @@ export default class SearchLightExt extends Extension {
   _release_ui() {
     if (this._entry) {
       if (this._entry.get_parent()) {
+        this._entry.hide();
         this._entry.get_parent().remove_child(this._entry);
       }
       this._entryParent.add_child(this._entry);

--- a/extension.js
+++ b/extension.js
@@ -491,9 +491,19 @@ export default class SearchLightExt extends Extension {
     if (this._isDraggingIcon()) {
       return;
     }
+    // Re-entrancy guard: _release_ui() hides the entry, which flips the
+    // stage key-focus -> _onKeyFocusChanged -> hide() again, re-entering
+    // teardown while the first pass is still mid-unmap -> Clutter aborts
+    // with clutter_actor_real_unrealize "!clutter_actor_is_mapped". Make
+    // the re-entrant hide() a no-op so teardown runs exactly once.
+    if (this._hiding) {
+      return;
+    }
+    this._hiding = true;
 
     this._release_ui();
     this._remove_events();
+    this._hiding = false;
 
     if (this._useAnimations) {
       this.mainContainer.ease({


### PR DESCRIPTION
Launching an app from the overlay on GNOME 50 sometimes aborts the whole shell (on Wayland that means losing the session, and GNOME's crash protection then disables all extensions):

```
Clutter:ERROR:../clutter/clutter/clutter-actor.c:1989:clutter_actor_real_unrealize:
  assertion failed: (!clutter_actor_is_mapped (self))
== Stack trace for context ==
#0  extension.js:755 (_release_ui)
#1  extension.js:495 (hide)
#2  extension.js:1012
```

Caught it with a coredump on Fedora 44 / gnome-shell 50.2 / Wayland. `_release_ui()` calls `remove_child()` on the entry while the overlay is still mapped, and clutter 18's stricter unrealize assertions abort on that.

Hiding the entry first unmaps it so the detach is safe. There's no visible difference since the whole overlay is fading out at that point anyway.

This is probably what #82 and #133 have been hitting too.