### PR TITLE
Defer the panel-button toggle out of the press gesture (shell crash, GNOME 48+)

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -281,7 +281,20 @@ export default class SearchLightExt extends Extension {
     this._indicator.set_child(icon);
     this._indicator.connectObject(
       'button-press-event',
-      this._toggle_search_light.bind(this),
+      () => {
+        // Defer the toggle out of the press gesture's handler: show()
+        // reparents the entry/search actors and grabs key focus, and doing
+        // that synchronously while the Clutter press gesture is in flight
+        // corrupts its state machine on GNOME 48+ (Clutter 18), aborting the
+        // shell with clutter-gesture.c:set_state assertion (new_state ==
+        // CLUTTER_GESTURE_STATE_POSSIBLE). idle_add lets the gesture finish
+        // first (imperceptible, one tick).
+        GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
+          this._toggle_search_light();
+          return GLib.SOURCE_REMOVE;
+        });
+        return Clutter.EVENT_STOP;
+      },
       this,
     );
     try {


### PR DESCRIPTION
### Symptom

Clicking the search-light **panel button** can abort the whole GNOME Shell (on Wayland this ends the session; after a couple of crashes GNOME drops into safe-mode and disables all extensions):

```
Clutter:ERROR clutter-gesture.c:544 set_state:
  assertion failed: (new_state == CLUTTER_GESTURE_STATE_POSSIBLE)
  clutter_press_gesture_point_began <- clutter_gesture_handle_event
```

### Cause

The `'button-press-event'` handler calls `_toggle_search_light() → show()` **synchronously while the Clutter press gesture is still in flight**. `show()` reparents the entry/search actors and grabs key focus; mutating the actor tree mid-gesture corrupts the gesture state machine, and the next gesture point event asserts → SIGABRT.

### Fix

Defer the toggle with `GLib.idle_add` so the press gesture completes before any actor surgery runs — imperceptible (one idle tick). `GLib`/`Clutter` are already imported.

This is the **sibling of #164**, which fixes the same class of crash on the app-launch (`_release_ui`) path. Likely the same root cause behind **#82** ("crash if used first after boot") and **#133** ("crash on startup use when Tiling Shell is also enabled").

### Testing

GNOME 50 / Fedora 44: before, clicking the panel button reliably SIGABRTs gnome-shell (coredump-confirmed on 2026-06-13); after, it opens normally and stays stable.