### PR TITLE
Fix search window getting stuck when hidden during the show animation

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -492,6 +492,11 @@ export default class SearchLightExt extends Extension {
       return;
     }
 
+    if (this._animSeq) {
+      this._hiTimer.cancel(this._animSeq);
+      this._animSeq = null;
+    }
+
     this._release_ui();
     this._remove_events();
 


### PR DESCRIPTION
`hide()` did not cancel the pending `_animSeq` show-animation timer scheduled by `show()`. When the window is hidden within the ~100 ms animation window, the orphaned timer fires *after* `_release_ui()`/`_remove_events()` have run, re-executing `_layout()` (which sets `_visible = true`) and re-easing the now-empty container back to opacity 255. The search box gets stuck on screen, unresponsive, with the search entry removed (placeholder gone) and no key handlers, and can only be recovered by reloading the extension (#146)

Fix: cancel `_animSeq` at the top of `hide()`, mirroring the guard in `show()`.