### PR TITLE
Fix blur background for wallpaper paths with special characters

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -335,7 +335,15 @@ export default class SearchLightExt extends Extension {
       //   let a = Math.floor(100 - color[3] * 100);
       //   let rgb = this._style.hex(color);
       // 	 let cmd = `convert -scale 10% -blur 0x2.5 -resize 200% -fill "${rgb}" -tint ${a} "${bg}" ${this.desktop_background_blurred}`;
-      let cmd = `convert -scale 10% -blur 0x2.5 -resize 200% "${this.desktop_background}" ${this.desktop_background_blurred}`;
+      // picture-uri is a file:// URI; decode it (spaces etc. are
+      // percent-encoded) before handing the path to imagemagick
+      let bgPath = this.desktop_background;
+      try {
+        [bgPath] = GLib.filename_from_uri(this.desktop_background);
+      } catch (err) {
+        // not a file:// URI; use as-is
+      }
+      let cmd = `convert -scale 10% -blur 0x2.5 -resize 200% "${bgPath}" ${this.desktop_background_blurred}`;
       console.log(cmd);
       trySpawnCommandLine(cmd);
     }


### PR DESCRIPTION
## Problem

The blur-background feature passes the raw `picture-uri` gsettings value directly to the `convert` command. When the wallpaper filename contains characters that get percent-encoded in the URI (e.g. a space encoded as `%20`), ImageMagick cannot open the file:

```
convert: unable to open image '/home/user/.local/share/backgrounds/Acrylic%205.png': No such file or directory @ error/blob.c/OpenBlob/3710.
convert: no images defined `/tmp/searchlight-user-bg-blurred.jpg' @ error/deprecate.c/ConvertImageCommand/3366.
```

The blurred background image is never generated, so enabling "Blur background" silently does nothing (gnome-shell then logs `Failed to load file:///tmp/searchlight-user-bg-blurred.jpg`).

## Fix

Decode the URI with `GLib.filename_from_uri()` in `_updateBlurredBackground()` so `convert` receives the actual filesystem path. Falls back to the raw value if the URI isn't a `file://` URI.

Tested on GNOME Shell (Wayland) with a wallpaper named `2024-10-27-18-35-47-Acrylic 5.png` — the blurred background now generates and displays correctly.
