### PR TITLE
docs: update README.md to reflect GNOME 50 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This is a Gnome Shell extension that takes the apps search widget out of Overvie
 ### Notice
 
 * Gnome 50 ready for testing
-* Gnome 49 and prior will now be under gnome-49 branch
+* Gnome 49 and prior will now be under g49 branch
 * Gnome 48 port is ready for testing
 * Gnome 47 and prior will now be under gnome-47 branch
 * Gnome 46 port is ready for testing

--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ This is a Gnome Shell extension that takes the apps search widget out of Overvie
 
 ### Notice
 
-* Gnome 48 ready for testing
-* Gnome 47 and prior will now be numer gnome-47 branch
+* Gnome 50 ready for testing
+* Gnome 49 and prior will now be under gnome-49 branch
+* Gnome 48 port is ready for testing
+* Gnome 47 and prior will now be under gnome-47 branch
 * Gnome 46 port is ready for testing
 * Gnome 45 port is ready for testing
 * Gnome 44 and prior will be under g44 branch


### PR DESCRIPTION
### Description
I noticed that GNOME 50 support was successfully added and merged in PR #154, but the `README.md` file was not updated and still stated that the extension only supported up to GNOME 48.

This PR updates the **Notice** section in the `README.md` to accurately reflect the current state of the `main` branch (GNOME 50).
