### PR TITLE
Fix GNOME 50 compatibility

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -453,7 +453,7 @@ export default class SearchLightExt extends Extension {
     this._updateCss();
     this._layout();
 
-    global.compositor.disable_unredirect();
+    // global.compositor.disable_unredirect(); 
 
     this.mainContainer.show();
     this.container.show();
@@ -507,14 +507,14 @@ export default class SearchLightExt extends Extension {
         onComplete: () => {
           this._visible = false;
           this.mainContainer.hide();
-          global.compositor.enable_unredirect();
+          // global.compositor.enable_unredirect();
         },
       });
     } else {
       this.mainContainer.opacity = 0;
       this._visible = false;
       this.mainContainer.hide();
-      global.compositor.enable_unredirect();
+      // global.compositor.enable_unredirect();
     }
     // this._hidePopups();
   }


### PR DESCRIPTION
GNOME 50 is Wayland only and no longer provides the X11 compositor backend, so global.compositor.disable_unredirect() and global.compositor.enable_unredirect() are no longer available and cause the extension to crash.

These calls were used to tell the X11 compositor to stop compositing while the search overlay was visible as a performance optimization. This is no longer necessary on Wayland, so the calls can be safely removed.

Changes

Removed three calls from extension.js:

global.compositor.disable_unredirect() from show()
global.compositor.enable_unredirect() from the hide() branch
global.compositor.enable_unredirect() from the other hide() branch

Tested On : 
Fedora Linux 44 (Workstation Edition) x86_64
GNOME 50.4

<img width="1905" height="1080" alt="image" src="https://github.com/user-attachments/assets/8f6918ad-c449-4547-a641-c72dd17bdd5a" />
<img width="1905" height="1080" alt="image" src="https://github.com/user-attachments/assets/fe6bca62-efd7-49f2-b671-ad491a92e720" />
